### PR TITLE
added archive_url to dump

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -30,19 +30,22 @@ def main_job(context):
                 commented_retweet = tweets.get_commented_retweet(msg)
                 if msg.media is None and commented_retweet is not None:
                     msg = commented_retweet
-                # saving tweet for debugging
-                json.dump(msg.AsDict(), config.m)
-                config.m.flush()
+                msg_dict = msg.AsDict()
                 if str(msg.id) in config.config["cached"]:
+                    msg_dict["archive_url"] = "cached"
                     logging.info("tweet {} is cached! sending cached link".format(msg.id))
                     confirm_save(mention.id, config.config["cached"][str(msg.id)])
                 else:
                     tg = save_in_telegram(msg, context)
                     if tg is None:
+                        msg_dict["archive_url"] = None
                         logging.info("error saving in telegram")
                     else:
-                        pass
+                        msg_dict["archive_url"] = tg.link
                         confirm_save(mention.id, tg.link)
+                # saving tweet for debugging
+                json.dump(msg_dict, config.m)
+                config.m.flush()
             elif use is False:
                 confirm_error(mention.id,
                               "Hiciste muchos intentos en muy poco tiempo. "


### PR DESCRIPTION
- I gave priority to not doing 2 dumps vs adding more code (idk if it bothers you for debugging that the dump is done after doing stuff)
- I also recorded if the tweet was cached or there was an error 
- Line 44 works with tg.caption in the tester, but I think that we have different API versions if its working fine now with tg.link 